### PR TITLE
Add tests for Ids, Unops, and function Calls

### DIFF
--- a/test/parser/_arithmetic.in
+++ b/test/parser/_arithmetic.in
@@ -4,6 +4,8 @@ state 1 * 2.1
 state 1 / 2.1
 state 1 % 2.1
 state 1 ** 2.1
+state -42
+state 1 + -43
 state 1 * 2 + 3 ** 4
 state 1 / 2 % 3 % 4
 state 1 + 2 - 3 / 4

--- a/test/parser/_arithmetic.out
+++ b/test/parser/_arithmetic.out
@@ -1,17 +1,19 @@
 [
-	State(Binop(Int_lit(1), Add, Float_lit(2.1)));
-	State(Binop(Int_lit(1), Sub, Float_lit(2.1)));
-	State(Binop(Int_lit(1), Mult, Float_lit(2.1)));
-	State(Binop(Int_lit(1), Div, Float_lit(2.1)));
-	State(Binop(Int_lit(1), Mod, Float_lit(2.1)));
-	State(Binop(Int_lit(1), Pow, Float_lit(2.1)));
+	State(Binop(Int_lit(1), Add, Float_lit(2.1))) ;
+	State(Binop(Int_lit(1), Sub, Float_lit(2.1))) ;
+	State(Binop(Int_lit(1), Mult, Float_lit(2.1))) ;
+	State(Binop(Int_lit(1), Div, Float_lit(2.1))) ;
+	State(Binop(Int_lit(1), Mod, Float_lit(2.1))) ;
+	State(Binop(Int_lit(1), Pow, Float_lit(2.1))) ;
+	State(Unop(Sub, Int_lit(42))) ;
+	State(Binop(Int_lit(1), Add, Unop(Sub, Int_lit(43)))) ;
 	State(
 		Binop(
 			Binop(Int_lit(1), Mult, Int_lit(2)),
 			Add,
 			Binop(Int_lit(3), Pow, Int_lit(4))
 		)
-	);
+	) ;
 	State(
 		Binop(
 			Binop(
@@ -22,14 +24,14 @@
 			Mod,
 			Int_lit(4)
 		)
-	);
+	) ;
 	State(
 		Binop(
 			Binop(Int_lit(1), Add, Int_lit(2)),
 			Sub,
 			Binop(Int_lit(3), Div, Int_lit(4))
 		)
-	);
+	) ;
 	State(
 		Binop(
 			Int_lit(1),

--- a/test/parser/_id_call.in
+++ b/test/parser/_id_call.in
@@ -3,3 +3,4 @@ state myvar
 state print(40 + 2)
 state print("fourty-two")
 state myfunc(arg1, arg2)
+state prec(myvar, 2 * (2 + 3))

--- a/test/parser/_id_call.in
+++ b/test/parser/_id_call.in
@@ -3,4 +3,5 @@ state myvar
 state print(40 + 2)
 state print("fourty-two")
 state myfunc(arg1, arg2)
+state noargs()
 state prec(myvar, 2 * (2 + 3))

--- a/test/parser/_id_call.in
+++ b/test/parser/_id_call.in
@@ -1,0 +1,5 @@
+state PI
+state myvar
+state print(40 + 2)
+state print("fourty-two")
+state myfunc(arg1, arg2)

--- a/test/parser/_id_call.out
+++ b/test/parser/_id_call.out
@@ -3,5 +3,14 @@
     State(Id(myvar)) ;
     State(Call(Id(print), [Binop(Int_lit(40), Add, Int_lit(2))])) ;
     State(Call(Id(print), [String_lit(fourty-two)])) ;
-    State(Call(Id(myfunc), [Id(arg1) ; Id(arg2)]))
+    State(Call(Id(myfunc), [Id(arg1) ; Id(arg2)])) ;
+    State(
+        Call(
+            Id(prec),
+            [
+                Id(myvar) ;
+                Binop(Int_lit(2), Mult, Binop(Int_lit(2), Add, Int_lit(3)))
+            ]
+        )
+    )
 ]

--- a/test/parser/_id_call.out
+++ b/test/parser/_id_call.out
@@ -4,6 +4,7 @@
     State(Call(Id(print), [Binop(Int_lit(40), Add, Int_lit(2))])) ;
     State(Call(Id(print), [String_lit(fourty-two)])) ;
     State(Call(Id(myfunc), [Id(arg1) ; Id(arg2)])) ;
+    State(Call(Id(noargs), [])) ;
     State(
         Call(
             Id(prec),

--- a/test/parser/_id_call.out
+++ b/test/parser/_id_call.out
@@ -1,0 +1,7 @@
+[
+    State(Id(PI)) ;
+    State(Id(myvar)) ;
+    State(Call(Id(print), [Binop(Int_lit(40), Add, Int_lit(2))])) ;
+    State(Call(Id(print), [String_lit(fourty-two)])) ;
+    State(Call(Id(myfunc), [Id(arg1) ; Id(arg2)]))
+]

--- a/test/parser/parserize.ml
+++ b/test/parser/parserize.ml
@@ -1,29 +1,35 @@
 open Ast 
 
-let rec eval = function
+let txt_of_op = function
+  | Add -> "Add"
+  | Sub -> "Sub"
+  | Mult -> "Mult"
+  | Div -> "Div"
+  | Mod -> "Mod"
+  | Pow -> "Pow"
+
+let rec txt_of_expr = function
   | Int_lit(x) -> "Int_lit(" ^ string_of_int x ^ ")"
   | Float_lit(x) -> "Float_lit(" ^ string_of_float x ^ ")"
   | String_lit(x) -> "String_lit(" ^ x ^ ")"
-  | Unop(op, e1) ->
-    let v1 = eval e1 in "Unop(Sub, " ^ v1 ^ ")"
+  | Id(x) -> "Id(" ^ x ^ ")"
+  | Unop(op, e1) -> let v1 = txt_of_expr e1 and op1 = txt_of_op op in
+    "Unop(" ^ op1 ^ ", " ^ v1 ^ ")"
   | Binop(e1, op, e2) ->
-    let v1 = eval e1 and v2 = eval e2 in match op with
-      | Add -> "Binop(" ^ v1 ^ ", Add, " ^ v2 ^ ")"
-      | Sub -> "Binop(" ^ v1 ^ ", Sub, " ^ v2 ^ ")"
-      | Mult -> "Binop(" ^ v1 ^ ", Mult, " ^ v2 ^ ")"
-      | Div -> "Binop(" ^ v1 ^ ", Div, " ^ v2 ^ ")"
-      | Mod -> "Binop(" ^ v1 ^ ", Mod, " ^ v2 ^ ")"
-      | Pow -> "Binop(" ^ v1 ^ ", Pow, " ^ v2 ^ ")"
+    let v1 = txt_of_expr e1 and op1 = txt_of_op op and v2 = txt_of_expr e2 in
+    "Binop(" ^ v1 ^ ", " ^ op1 ^ ", " ^ v2 ^ ")"
+  | Call(f, args) -> let args1 = List.map txt_of_expr args in
+    "Call(Id(" ^ f ^ "), [" ^ String.concat " ; " args1 ^ "])"
 
-let rec eval_stmts acc = function
+let rec txt_of_stmt = function
+  | State(expr) -> let e = txt_of_expr expr in "State(" ^ e ^ ")"
+
+let rec txt_of_stmts acc = function
   | [] -> "[" ^ (String.concat " ; " acc) ^ "]"
-  | stmt :: tl -> match stmt with
-    | State(e) ->
-      let e1 = eval e in eval_stmts (("State(" ^ e1 ^ ")") :: acc) tl
+  | stmt :: tl -> txt_of_stmts (txt_of_stmt stmt :: acc) tl
 
 let _ =
   let lexbuf = Lexing.from_channel stdin in
   let expr = Parser.program Scanner.token lexbuf in
-  let result = eval_stmts [] expr in
+  let result = txt_of_stmts [] expr in
   print_endline result
-  


### PR DESCRIPTION
Please remember to add tests when you add functionality to the parser! This PR adds tests for the negation `Unop`, `IDs`, and function `Calls`.

cc @lillyfwang @alexandramedway @dannyech for merge