### PR TITLE
Parse function call identifiers as Ids instead of strings

### DIFF
--- a/compiler/ast.mli
+++ b/compiler/ast.mli
@@ -31,7 +31,7 @@ type expr =                      (* Expressions *)
   | Id of string                 (* x *)
   | Unop of op * expr            (* -5 *)
   | Binop of expr * op * expr    (* a + b *)
-  | Call of string * expr list   (* add(1, 2) *)
+  | Call of expr * expr list     (* add(1, 2) *)
 
 type stmt =         (* Statements *)
   | Do of expr    (* set foo = bar + 3 *)

--- a/compiler/generator.ml
+++ b/compiler/generator.ml
@@ -52,7 +52,7 @@ let rec txt_of_expr = function
   | Unop(op, e) -> sprintf "(%s%s)" (txt_of_op op) (txt_of_expr e)
   | Binop(e1, op, e2) ->
       sprintf "(%s %s %s)" (txt_of_expr e1) (txt_of_op op) (txt_of_expr e2)
-  | Call(f, args) -> txt_of_func_call f args
+  | Call(f, args) -> txt_of_func_call (txt_of_expr f) args
 
 and txt_of_func_call f args = match f with
   | "print" -> sprintf "print(%s)" (txt_of_args args)

--- a/compiler/parser.mly
+++ b/compiler/parser.mly
@@ -83,7 +83,7 @@ expr:
   | arith                       { $1 }
   | boolean                     { $1 }
   | ID                          { Id($1) }
-  | ID LPAREN args_opt RPAREN   { Call($1, $3)}
+  | ID LPAREN args_opt RPAREN   { Call(Id($1), $3)}
   | LPAREN expr RPAREN          { $2 }
 
 arith:

--- a/test/parser/_id_call.out
+++ b/test/parser/_id_call.out
@@ -1,13 +1,13 @@
 [
     Do(Id(PI)) ;
     Do(Id(myvar)) ;
-    Do(Call(print, [Binop(Int_lit(40), Add, Int_lit(2))])) ;
-    Do(Call(print, [String_lit(fourty-two)])) ;
-    Do(Call(myfunc, [Id(arg1) ; Id(arg2)])) ;
-    Do(Call(noargs, [])) ;
+    Do(Call(Id(print), [Binop(Int_lit(40), Add, Int_lit(2))])) ;
+    Do(Call(Id(print), [String_lit(fourty-two)])) ;
+    Do(Call(Id(myfunc), [Id(arg1) ; Id(arg2)])) ;
+    Do(Call(Id(noargs), [])) ;
     Do(
         Call(
-            prec,
+            Id(prec),
             [
                 Id(myvar) ;
                 Binop(Int_lit(2), Mult, Binop(Int_lit(2), Add, Int_lit(3)))

--- a/test/parser/parserize.ml
+++ b/test/parser/parserize.ml
@@ -21,13 +21,12 @@ let rec txt_of_expr = function
   | String_lit(x) -> "String_lit(" ^ x ^ ")"
   | Bool_lit(x) -> "Bool_lit(" ^ string_of_bool x ^ ")"
   | Id(x) -> "Id(" ^ x ^ ")"
-  | Unop(op, e1) -> let v1 = txt_of_expr e1 and op1 = txt_of_op op in
-    "Unop(" ^ op1 ^ ", " ^ v1 ^ ")"
+  | Unop(op, e) -> "Unop(" ^ (txt_of_op op) ^ ", " ^ (txt_of_expr e) ^ ")"
   | Binop(e1, op, e2) ->
     let v1 = txt_of_expr e1 and op1 = txt_of_op op and v2 = txt_of_expr e2 in
     "Binop(" ^ v1 ^ ", " ^ op1 ^ ", " ^ v2 ^ ")"
   | Call(f, args) -> let args1 = List.map txt_of_expr args in
-    "Call(" ^ f ^ ", [" ^ String.concat " ; " args1 ^ "])"
+    "Call(" ^ (txt_of_expr f) ^ ", [" ^ String.concat " ; " args1 ^ "])"
 
 let rec txt_of_stmt = function
   | Do(expr) -> let e = txt_of_expr expr in "Do(" ^ e ^ ")"


### PR DESCRIPTION
Address #38: Parse `myfunc()` as `Call(Id(myfunc), [])` instead of `Call(myfunc, [])`. Makes no difference for code generation but myfunc is an identifier so semantically makes more sense. Also might make it easier to do lookups since we can have our `Id` generator case always hook into the hashmap to find the correct variable or function name.