### PR TITLE
Add pretty printer to allow easy indentation

### DIFF
--- a/compiler/Makefile
+++ b/compiler/Makefile
@@ -4,12 +4,13 @@
 OCAMLC=ocamlc
 OCAMLLEX=ocamllex
 OCAMLYACC=ocamlyacc
+LIBS=str.cma
 OBJS=parser.cmo scanner.cmo generator.cmo printer.cmo odds.cmo
 
 default: odds
 
 odds: $(OBJS)
-	$(OCAMLC) -g -o odds $(OBJS)
+	$(OCAMLC) -g -o odds $(LIBS) $(OBJS)
 
 all:
 	cd ..; make all

--- a/compiler/Makefile
+++ b/compiler/Makefile
@@ -4,7 +4,7 @@
 OCAMLC=ocamlc
 OCAMLLEX=ocamllex
 OCAMLYACC=ocamlyacc
-OBJS=parser.cmo scanner.cmo generator.cmo process.cmo odds.cmo
+OBJS=parser.cmo scanner.cmo generator.cmo printer.cmo odds.cmo
 
 default: odds
 

--- a/compiler/Makefile
+++ b/compiler/Makefile
@@ -4,7 +4,7 @@
 OCAMLC=ocamlc
 OCAMLLEX=ocamllex
 OCAMLYACC=ocamlyacc
-OBJS=parser.cmo scanner.cmo generator.cmo odds.cmo
+OBJS=parser.cmo scanner.cmo generator.cmo process.cmo odds.cmo
 
 default: odds
 

--- a/compiler/generator.ml
+++ b/compiler/generator.ml
@@ -68,9 +68,9 @@ and txt_of_list env = function
 let txt_of_stmt env = function
   | Do(e) -> let env, e = txt_of_expr env e in env, sprintf "%s" e
 
-let gen_stmts program = 
+let txt_of_stmts stmt_list = 
   let rec process_stmts env acc = function
-    | [] -> List.rev acc
+    | [] -> String.concat "\n" (List.rev acc)
     | stmt :: tl -> let updated_env, stmt_txt = txt_of_stmt env stmt in
         process_stmts updated_env (stmt_txt :: acc) tl
-  in process_stmts StringMap.empty [] program
+  in process_stmts StringMap.empty [] stmt_list

--- a/compiler/generator.ml
+++ b/compiler/generator.ml
@@ -68,15 +68,9 @@ and txt_of_list env = function
 let txt_of_stmt env = function
   | Do(e) -> let env, e = txt_of_expr env e in env, sprintf "%s" e
 
-let txt_of_stmts stmt_list = 
+let gen_stmts program = 
   let rec process_stmts env acc = function
-    | [] -> String.concat "\n" (List.rev acc)
+    | [] -> List.rev acc
     | stmt :: tl -> let updated_env, stmt_txt = txt_of_stmt env stmt in
         process_stmts updated_env (stmt_txt :: acc) tl
-  in process_stmts StringMap.empty [] stmt_list
-
-(* Code generation entry point *)
-let gen_program output_file program =
-  let code = txt_of_stmts program in 
-  let file = open_out output_file in
-  fprintf file "%s\n" code; close_out file
+  in process_stmts StringMap.empty [] program

--- a/compiler/odds.ml
+++ b/compiler/odds.ml
@@ -10,13 +10,19 @@
 
 type action = Compile | Help | Raw
 
+let get_help =
+  "Odds Usage: odds.sh <flag> <input_file> <output_file>\n" ^
+  "  -c\tCompile odds input_file to python code in output_file\n" ^
+  "  -h\tDisplay this list of options\n" ^
+  "  -r\tCompile odds input_file to raw, pre-python code in output_file"
+
 let _ =
   let action =
     List.assoc Sys.argv.(1) [("-c", Compile) ; ("-h", Help) ; ("-r", Raw)] in
-  let lexbuf = Lexing.from_channel stdin in 
-  let output_file = Sys.argv.(2) in
-  let program = Parser.program Scanner.token lexbuf in 
-  match action with
-    | Compile -> Printer.gen_program output_file program
-    | Help -> print_endline "TODO: Add help prompt for compiler"
-    | Raw -> Printer.gen_raw output_file program
+  if action = Help then print_endline get_help else
+    let lexbuf = Lexing.from_channel stdin in 
+    let output_file = Sys.argv.(2) in
+    let program = Parser.program Scanner.token lexbuf in 
+    match action with
+      | Compile -> Printer.gen_program output_file program
+      | Raw -> Printer.gen_raw output_file program

--- a/compiler/odds.ml
+++ b/compiler/odds.ml
@@ -18,5 +18,5 @@ let _ =
   let program = Parser.program Scanner.token lexbuf in 
   match action with
     | Ast -> print_endline "TODO: Add pretty printer for AST"
-    | Compile -> Generator.gen_program output_file program
+    | Compile -> Process.gen_program output_file program
     | Help -> print_endline "TODO: Add help prompt for compiler"

--- a/compiler/odds.ml
+++ b/compiler/odds.ml
@@ -8,15 +8,15 @@
  *  - Lilly Wang
  *)
 
-type action = Ast | Compile | Help
+type action = Compile | Help | Raw
 
 let _ =
   let action =
-    List.assoc Sys.argv.(1) [("-a", Ast); ("-c", Compile); ("-h", Help)] in
+    List.assoc Sys.argv.(1) [("-c", Compile) ; ("-h", Help) ; ("-r", Raw)] in
   let lexbuf = Lexing.from_channel stdin in 
   let output_file = Sys.argv.(2) in
   let program = Parser.program Scanner.token lexbuf in 
   match action with
-    | Ast -> print_endline "TODO: Add pretty printer for AST"
     | Compile -> Printer.gen_program output_file program
     | Help -> print_endline "TODO: Add help prompt for compiler"
+    | Raw -> Printer.gen_raw output_file program

--- a/compiler/odds.ml
+++ b/compiler/odds.ml
@@ -18,5 +18,5 @@ let _ =
   let program = Parser.program Scanner.token lexbuf in 
   match action with
     | Ast -> print_endline "TODO: Add pretty printer for AST"
-    | Compile -> Process.gen_program output_file program
+    | Compile -> Printer.gen_program output_file program
     | Help -> print_endline "TODO: Add help prompt for compiler"

--- a/compiler/odds.sh
+++ b/compiler/odds.sh
@@ -1,12 +1,12 @@
 #!/bin/bash
 
-if [ "$#" -ne 3 ]; then
-  echo "Usage: $0 [flag] [input_file] [output_file]" 1>&2
-  exit 1
-fi
-
 MYDIR="$(dirname "$(which "$0")")"
 ODDS_FILE="$MYDIR/odds"
+
+if [ "$#" -ne 3 ] || [ "$1" == "-h" ]; then
+  $ODDS_FILE -h
+  exit 0
+fi
 
 cat $2 | $ODDS_FILE $1 $3
 

--- a/compiler/printer.ml
+++ b/compiler/printer.ml
@@ -1,5 +1,5 @@
 (*
- * COMS4115: Post-processor
+ * COMS4115: Post-process printer
  *
  * Authors:
  *  - Alex Kalicki

--- a/compiler/printer.ml
+++ b/compiler/printer.ml
@@ -20,8 +20,14 @@ let txt_of_stmts stmts =
   in aux [] 0 stmts
 
 (* Code generation entry point *)
+let gen_raw output_file program = 
+  let text = Generator.txt_of_stmts program in
+  let file = open_out output_file in
+  fprintf file "%s\n" text; close_out file
+
 let gen_program output_file program =
-  let stmts = Generator.gen_stmts program in
-  let code = txt_of_stmts stmts in
+  let text = Generator.txt_of_stmts program in
+  let split = Str.split (Str.regexp "\n") in
+  let code = txt_of_stmts (split text) in
   let file = open_out output_file in
   fprintf file "%s\n" code; close_out file

--- a/compiler/process.ml
+++ b/compiler/process.ml
@@ -1,0 +1,27 @@
+(*
+ * COMS4115: Post-processor
+ *
+ * Authors:
+ *  - Alex Kalicki
+ *  - Alexandra Medway
+ *  - Daniel Echikson
+ *  - Lilly Wang
+ *)
+
+open Printf
+
+let txt_of_stmts stmts =
+  let rec aux acc level = function
+    | [] -> String.concat "\n" (List.rev acc)
+    | line :: tl -> match line.[0] with
+      | '{' -> aux acc (level + 1) tl
+      | '}' -> aux acc (level - 1) tl
+      | _ -> let s = (String.make level '\t') ^ line in aux (s :: acc) level tl
+  in aux [] 0 stmts
+
+(* Code generation entry point *)
+let gen_program output_file program =
+  let stmts = Generator.gen_stmts program in
+  let code = txt_of_stmts stmts in
+  let file = open_out output_file in
+  fprintf file "%s\n" code; close_out file


### PR DESCRIPTION
 Flow: scanner --> parser --> generator --> printer

Post-processing step: take a partially generated list of strings. Use braces for beginning and end of indentation, and print all strings to a compiled python file. Also added a basic help prompt. Resolves #30 and #40.